### PR TITLE
Feature/raster.stack rework

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,3 +42,6 @@ build: off
 
 test_script:
     - coverage run --source spatialist/ -m pytest
+
+after_test:
+  - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ environment:
   matrix:
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\Miniconda3-x64
-      GDAL_DATA: C:\Miniconda3-x64\Library\share\gdal
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+      GDAL_DATA: C:\Miniconda36-x64\Library\share\gdal
       PROJECT_DIR: C:\projects\spatialist
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,5 +43,5 @@ build: off
 test_script:
     - coverage run --source spatialist/ -m pytest
 
-after_test:
-  - coveralls
+#after_test:
+#  - coveralls

--- a/spatialist/ancillary.py
+++ b/spatialist/ancillary.py
@@ -341,6 +341,14 @@ def multicore(function, cores, multiargs, **singleargs):
             return out
 
 
+def add(x, y, z):
+    """
+    only a dummy function for testing the multicore function
+    defining it in the test script is not possible since it cannot be serialized
+    with a reference module that does not exist (i.e. the test script)
+    """
+    return x + y + z
+
 class ExceptionWrapper(object):
     """
     | class for enabling traceback pickling in function multiprocess

--- a/spatialist/ancillary.py
+++ b/spatialist/ancillary.py
@@ -6,6 +6,9 @@
 This script gathers central functions and classes for general applications
 """
 import sys
+import dill
+import tempfile
+import platform
 import tblib.pickling_support
 
 if sys.version_info >= (3, 0):
@@ -267,43 +270,75 @@ def multicore(function, cores, multiargs, **singleargs):
     processlist = [dictmerge(dict([(arg, multiargs[arg][i]) for arg in multiargs]), singleargs)
                    for i in range(len(multiargs[list(multiargs.keys())[0]]))]
     
-    # block printing of the executed function
-    results = None
-    
-    def wrapper(**kwargs):
-        try:
-            return function(**kwargs)
-        except Exception as e:
-            return ExceptionWrapper(e)
-    
-    with HiddenPrints():
-        # start pool of processes and do the work
-        try:
-            pool = mp.Pool(processes=cores)
-        except NameError:
-            raise ImportError("package 'pathos' could not be imported")
-        results = pool.imap(lambda x: wrapper(**x), processlist)
-        pool.close()
-        pool.join()
-    
-    i = 0
-    out = []
-    for item in results:
-        if isinstance(item, ExceptionWrapper):
-            item.ee = type(item.ee)(str(item.ee) +
-                                    "\n(called function '{}' with args {})"
-                                    .format(function.__name__, processlist[i]))
-            raise (item.re_raise())
-        out.append(item)
-        i += 1
-    
-    # evaluate the return of the processing function;
-    # if any value is not None then the whole list of results is returned
-    eval = [x for x in out if x is not None]
-    if len(eval) == 0:
-        return None
+    if platform.system() == 'Windows':
+        
+        # in Windows parallel processing needs to strictly be in a "if __name__ == '__main__':" wrapper
+        # it was thus necessary to outsource this to a different script and try to serialize all input for sharing objects
+        # https://stackoverflow.com/questions/38236211/why-multiprocessing-process-behave-differently-on-windows-and-linux-for-global-o
+        
+        # a helper script to perform the parallel processing
+        script = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'multicore_helper.py')
+        
+        # a temporary file to write the serialized function variables
+        tmpfile = os.path.join(tempfile.gettempdir(), 'spatialist_dump')
+        
+        # check if everything can be serialized
+        if not dill.pickles([function, cores, processlist]):
+            raise RuntimeError('cannot fully serialize function arguments;\n'
+                               ' see https://github.com/uqfoundation/dill for supported types')
+        
+        # write the serialized variables
+        with open(tmpfile, 'wb') as tmp:
+            dill.dump([function, cores, processlist], tmp, byref=False)
+        
+        # run the helper script
+        proc = sp.Popen([sys.executable, script], stdin=sp.PIPE, stderr=sp.PIPE)
+        out, err = proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(err.decode())
+        
+        # retrieve the serialized output of the processing which was written to the temporary file by the helper script
+        with open(tmpfile, 'rb') as tmp:
+            result = dill.load(tmp)
+        return result
     else:
-        return out
+        results = None
+        
+        def wrapper(**kwargs):
+            try:
+                return function(**kwargs)
+            except Exception as e:
+                return ExceptionWrapper(e)
+        
+        # block printing of the executed function
+        with HiddenPrints():
+            # start pool of processes and do the work
+            try:
+                pool = mp.Pool(processes=cores)
+            except NameError:
+                raise ImportError("package 'pathos' could not be imported")
+            results = pool.imap(lambda x: wrapper(**x), processlist)
+            pool.close()
+            pool.join()
+        
+        i = 0
+        out = []
+        for item in results:
+            if isinstance(item, ExceptionWrapper):
+                item.ee = type(item.ee)(str(item.ee) +
+                                        "\n(called function '{}' with args {})"
+                                        .format(function.__name__, processlist[i]))
+                raise (item.re_raise())
+            out.append(item)
+            i += 1
+        
+        # evaluate the return of the processing function;
+        # if any value is not None then the whole list of results is returned
+        eval = [x for x in out if x is not None]
+        if len(eval) == 0:
+            return None
+        else:
+            return out
 
 
 class ExceptionWrapper(object):

--- a/spatialist/auxil.py
+++ b/spatialist/auxil.py
@@ -123,7 +123,10 @@ def gdalwarp(src, dst, options):
     -------
 
     """
-    out = gdal.Warp(dst, src, options=gdal.WarpOptions(**options))
+    try:
+        out = gdal.Warp(dst, src, options=gdal.WarpOptions(**options))
+    except RuntimeError as e:
+        raise RuntimeError('{}:\n  src: {}\n  dst: {}\n  options: {}'.format(str(e), src, dst, options))
     out = None
 
 

--- a/spatialist/envi.py
+++ b/spatialist/envi.py
@@ -115,7 +115,7 @@ class HDRobject(object):
                     while '}' not in line:
                         i += 1
                         line += lines[i].strip('\n').lstrip()
-                line = list(filter(None, re.split('\s+=\s+', line)))
+                line = list(filter(None, re.split(r'\s+=\s+', line)))
                 line[1] = re.split(',[ ]*', line[1].strip('{}'))
                 key = line[0].replace(' ', '_')
                 val = line[1] if len(line[1]) > 1 else line[1][0]

--- a/spatialist/multicore_helper.py
+++ b/spatialist/multicore_helper.py
@@ -1,5 +1,5 @@
 #################################################################
-# helper script to be able to use function ancilary.multicore on
+# helper script to be able to use function ancillary.multicore on
 # Windows operating systems
 # John Truckenbrodt 2019
 #################################################################

--- a/spatialist/multicore_helper.py
+++ b/spatialist/multicore_helper.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+import dill
+
+try:
+    import pathos.multiprocessing as mp
+except ImportError:
+    pass
+
+from spatialist.ancillary import HiddenPrints
+
+if __name__ == '__main__':
+    
+    tmpfile = os.path.join(tempfile.gettempdir(), 'spatialist_dump')
+    with open(tmpfile, 'rb') as tmp:
+        func, cores, processlist = dill.load(tmp)
+    
+    processlist = [dill.dumps([func, x]) for x in processlist]
+    
+    
+    def wrapper(job):
+        import dill
+        function, proc = dill.loads(job)
+        return function(**proc)
+    
+    
+    with HiddenPrints():
+        # start pool of processes and do the work
+        try:
+            pool = mp.Pool(processes=cores)
+        except NameError:
+            raise ImportError("package 'pathos' could not be imported")
+        results = pool.imap(wrapper, processlist)
+        pool.close()
+        pool.join()
+    
+    outlist = list(results)
+    
+    # evaluate the return of the processing function;
+    # if any value is not None then the whole list of results is returned
+    eval = [x for x in outlist if x is not None]
+    if len(eval) == 0:
+        out = None
+    else:
+        out = outlist
+    
+    with open(tmpfile, 'wb') as tmp:
+        dill.dump(out, tmp, byref=False)

--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -1069,8 +1069,8 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
         shp.reproject(srs)
         ext = shp.extent
         arg_ext = (ext['xmin'], ext['ymin'], ext['xmax'], ext['ymax'])
-        for i in range(len(srcfiles)):
-            group = sorted(srcfiles[i], key=sortfun) if isinstance(srcfiles[i], list) else [srcfiles[i]]
+        for i, item in enumerate(srcfiles):
+            group = sorted(item, key=sortfun) if isinstance(item, list) else [item]
             group = [x for x in group if intersect(shp, Raster(x).bbox())]
             if len(group) > 1:
                 srcfiles[i] = group
@@ -1083,7 +1083,7 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
         arg_ext = None
     
     dst_base = os.path.splitext(dstfile)[0]
-
+    
     options_warp = {'options': ['-q'],
                     'format': 'GTiff' if separate else 'ENVI',
                     'outputBounds': arg_ext, 'multithread': True,

--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -1107,10 +1107,10 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
         gdalbuildvrt(group, vrt, options_buildvrt)
         srcfiles[i] = vrt
     
-    # if no specific layernames are defined and sortfun is not set to None,
+    # if no specific layernames are defined,
     # sort files by custom function or, by default, the basename of the raster/VRT file
-    if layernames is None and sortfun is not None:
-        srcfiles = sorted(srcfiles, key=sortfun if sortfun else os.path.basename)
+    if layernames is None:
+        srcfiles = sorted(srcfiles, key=sortfun if sortfun is not None else os.path.basename)
     
     bandnames = [os.path.splitext(os.path.basename(x))[0] for x in srcfiles] if layernames is None else layernames
     

--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -762,7 +762,7 @@ class Raster(object):
         if os.path.isfile(outname) and not overwrite:
             raise RuntimeError('target file already exists')
         
-        if format == 'GTiff' and not re.search('\.tif[f]*$', outname):
+        if format == 'GTiff' and not re.search(r'\.tif[f]*$', outname):
             outname += '.tif'
         
         dtype = Dtype(self.dtype if dtype == 'default' else dtype).gdalint

--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -1,6 +1,6 @@
 #################################################################
 # GDAL wrapper for convenient raster data handling and processing
-# John Truckenbrodt 2015-2018
+# John Truckenbrodt 2015-2019
 #################################################################
 
 
@@ -1065,7 +1065,7 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
     
     # read shapefile bounding coordinates and reduce list of rasters to those overlapping with the shapefile
     if shapefile is not None:
-        shp = shapefile if isinstance(shapefile, Vector) else Vector(shapefile)
+        shp = shapefile.clone() if isinstance(shapefile, Vector) else Vector(shapefile)
         shp.reproject(srs)
         ext = shp.extent
         arg_ext = (ext['xmin'], ext['ymin'], ext['xmax'], ext['ymax'])
@@ -1078,6 +1078,7 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
                 srcfiles[i] = group[0]
             else:
                 srcfiles[i] = None
+        shp.close()
         srcfiles = list(filter(None, srcfiles))
     else:
         arg_ext = None

--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -1120,6 +1120,9 @@ def stack(srcfiles, dstfile, resampling, targetres, srcnodata, dstnodata, shapef
     # use the file basenames without extension as band names if none are defined
     bandnames = [os.path.splitext(os.path.basename(x))[0] for x in srcfiles] if layernames is None else layernames
     
+    if len(list(set(bandnames))) != len(bandnames):
+        raise RuntimeError('output bandnames are not unique')
+    
     if separate:
         if not os.path.isdir(dstfile):
             os.makedirs(dstfile)

--- a/spatialist/sqlite_util.py
+++ b/spatialist/sqlite_util.py
@@ -18,12 +18,12 @@ errormessage = 'sqlite3 does not support loading extensions and {}; ' \
                'please refer to the spatialist installation instructions'
 try:
     import sqlite3
-
+    
     check_loading()
 except RuntimeError:
     try:
         from pysqlite2 import dbapi2 as sqlite3
-
+        
         check_loading()
     except ImportError:
         raise RuntimeError(errormessage.format('pysqlite2 does not exist as alternative'))
@@ -96,7 +96,7 @@ class __Handler(object):
         print('using sqlite version {}'.format(self.version['sqlite']))
         if 'spatialite' in self.version.keys():
             print('using spatialite version {}'.format(self.version['spatialite']))
-
+    
     @property
     def version(self):
         out = {'sqlite': sqlite3.sqlite_version}
@@ -108,7 +108,7 @@ class __Handler(object):
         except sqlite3.OperationalError:
             pass
         return out
-
+    
     def get_tablenames(self):
         cursor = self.conn.cursor()
         cursor.execute('SELECT * FROM sqlite_master WHERE type="table"')
@@ -116,7 +116,7 @@ class __Handler(object):
         if bool(type('unicode')):
             names = [str(x) for x in names]
         return names
-
+    
     def load_extension(self, extension):
         if re.search('spatialite', extension):
             spatialite_setup()
@@ -132,11 +132,11 @@ class __Handler(object):
                 except sqlite3.OperationalError as e:
                     print('{0}: {1}'.format(option, str(e)))
                     continue
-
+            
             # if loading mod_spatialite fails try to load libspatialite directly
             if select is None:
                 self.__load_regular('spatialite')
-
+            
             # initialize spatial support
             if 'spatial_ref_sys' not in self.get_tablenames():
                 cursor = self.conn.cursor()
@@ -147,26 +147,26 @@ class __Handler(object):
                     # mod_spatialite extension
                     cursor.execute('SELECT InitSpatialMetaData(1);')
                 self.conn.commit()
-
+        
         else:
             self.__load_regular(extension)
-
+    
     def __load_regular(self, extension):
         options = []
-
+        
         # create an extension library option starting with 'lib' without extension suffices;
         # e.g. 'libgdal' but not 'gdal.so'
         ext_base = self.__split_ext(extension)
         if not ext_base.startswith('lib'):
             ext_base = 'lib' + ext_base
         options.append(ext_base)
-
+        
         # get the full extension library name; e.g. 'libgdal.so.20'
         ext_mod = find_library(extension.replace('lib', ''))
         if ext_mod is None:
             raise RuntimeError('no library found for extension {}'.format(extension))
         options.append(ext_mod)
-
+        
         # loop through extension library name options and try to load them
         success = False
         for option in options:
@@ -178,12 +178,12 @@ class __Handler(object):
                 break
             except sqlite3.OperationalError:
                 continue
-
+        
         if not success:
             raise RuntimeError('failed to load extension {}'.format(extension))
 
     def __split_ext(self, extension):
         base = extension
-        while re.search('\.', base):
+        while re.search(r'\.', base):
             base = os.path.splitext(base)[0]
         return base

--- a/spatialist/sqlite_util.py
+++ b/spatialist/sqlite_util.py
@@ -181,8 +181,9 @@ class __Handler(object):
         
         if not success:
             raise RuntimeError('failed to load extension {}'.format(extension))
-
-    def __split_ext(self, extension):
+    
+    @staticmethod
+    def __split_ext(extension):
         base = extension
         while re.search(r'\.', base):
             base = os.path.splitext(base)[0]

--- a/spatialist/tests/test_ancillary.py
+++ b/spatialist/tests/test_ancillary.py
@@ -46,18 +46,17 @@ def test_which():
 
 
 def test_multicore():
-    add = lambda x, y, z: x + y + z
-    assert anc.multicore(add, cores=2, multiargs={'x': [1, 2]}, y=5, z=9) == [15, 16]
-    assert anc.multicore(add, cores=2, multiargs={'x': [1, 2], 'y': [5, 6]}, z=9) == [15, 17]
+    assert anc.multicore(anc.add, cores=2, multiargs={'x': [1, 2]}, y=5, z=9) == [15, 16]
+    assert anc.multicore(anc.add, cores=2, multiargs={'x': [1, 2], 'y': [5, 6]}, z=9) == [15, 17]
     # unknown argument in multiargs
     with pytest.raises(AttributeError):
-        anc.multicore(add, cores=2, multiargs={'foobar': [1, 2]}, y=5, z=9)
+        anc.multicore(anc.add, cores=2, multiargs={'foobar': [1, 2]}, y=5, z=9)
     # unknown argument in single args
     with pytest.raises(AttributeError):
-        anc.multicore(add, cores=2, multiargs={'x': [1, 2]}, y=5, foobar=9)
+        anc.multicore(anc.add, cores=2, multiargs={'x': [1, 2]}, y=5, foobar=9)
     # multiarg values of different length
     with pytest.raises(AttributeError):
-        anc.multicore(add, cores=2, multiargs={'x': [1, 2], 'y': [5, 6, 7]}, z=9)
+        anc.multicore(anc.add, cores=2, multiargs={'x': [1, 2], 'y': [5, 6, 7]}, z=9)
 
 
 def test_finder(tmpdir, testdata):

--- a/spatialist/tests/test_spatial.py
+++ b/spatialist/tests/test_spatial.py
@@ -171,8 +171,14 @@ def test_Raster_extract(testdata):
 
 def test_dtypes():
     assert Dtype('Float32').gdalint == 6
+    assert Dtype(6).gdalstr == 'Float32'
+    assert Dtype('uint32').gdalstr == 'UInt32'
     with pytest.raises(ValueError):
         Dtype('foobar')
+    with pytest.raises(ValueError):
+        Dtype(999)
+    with pytest.raises(TypeError):
+        Dtype(None)
 
 
 def test_stack(tmpdir, testdata):

--- a/spatialist/tests/test_spatial.py
+++ b/spatialist/tests/test_spatial.py
@@ -238,11 +238,11 @@ def test_stack(tmpdir, testdata):
         assert ras.bands == 2
     
     # pass shapefile and do mosaicing
-    outname = os.path.join(str(tmpdir), 'test3.tif')
+    outname = os.path.join(str(tmpdir), 'test3')
     with Raster(name).bbox() as box:
         stack(srcfiles=[[name, name]], resampling='near', targetres=tr, overwrite=True,
               srcnodata=-99, dstnodata=-99, dstfile=outname, shapefile=box)
-    with Raster(outname) as ras:
+    with Raster(outname + '.tif') as ras:
         assert ras.bands == 1
         assert ras.format == 'GTiff'
     
@@ -268,8 +268,12 @@ def test_stack(tmpdir, testdata):
     stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True, layernames=['test1', 'test2'],
           srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
     
-    # repeat with overwrite disabled
+    # repeat with overwrite disabled (no error raised, just a print message)
     stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=False, layernames=['test1', 'test2'],
+          srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
+
+    # repeat without layernames but sortfun
+    stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True, sortfun=os.path.basename,
           srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
 
 

--- a/spatialist/tests/test_spatial.py
+++ b/spatialist/tests/test_spatial.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import pytest
 import platform
 import numpy as np
@@ -222,7 +223,7 @@ def test_stack(tmpdir, testdata):
     
     # create a multi-band stack
     stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True,
-          srcnodata=-99, dstnodata=-99, dstfile=outname)
+          srcnodata=-99, dstnodata=-99, dstfile=outname, layernames=['test1', 'test2'])
     with Raster(outname) as ras:
         assert ras.bands == 2
         # Raster.rescale currently only supports one band
@@ -233,7 +234,7 @@ def test_stack(tmpdir, testdata):
     outname = os.path.join(str(tmpdir), 'test2')
     with Raster(name).bbox() as box:
         stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True,
-              srcnodata=-99, dstnodata=-99, dstfile=outname, shapefile=box)
+              srcnodata=-99, dstnodata=-99, dstfile=outname, shapefile=box, layernames=['test1', 'test2'])
     with Raster(outname) as ras:
         assert ras.bands == 2
     
@@ -273,7 +274,17 @@ def test_stack(tmpdir, testdata):
           srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
 
     # repeat without layernames but sortfun
-    stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True, sortfun=os.path.basename,
+    # bandnames not unique
+    outdir = os.path.join(str(tmpdir), 'subdir2')
+    with pytest.raises(RuntimeError):
+        stack(srcfiles=[name, name], resampling='near', targetres=tr, overwrite=True, sortfun=os.path.basename,
+              srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
+    
+    # repeat without layernames but sortfun
+    name2 = os.path.join(str(tmpdir), os.path.basename(name).replace('VV', 'XX'))
+    shutil.copyfile(name, name2)
+    outdir = os.path.join(str(tmpdir), 'subdir2')
+    stack(srcfiles=[name, name2], resampling='near', targetres=tr, overwrite=True, sortfun=os.path.basename,
           srcnodata=-99, dstnodata=-99, dstfile=outdir, separate=True, compress=True)
 
 

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ################################################################
 # OGR wrapper for convenient vector data handling and processing
-# John Truckenbrodt 2015-2018
+# John Truckenbrodt 2015-2019
 ################################################################
 
 

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -204,6 +204,9 @@ class Vector(object):
         else:
             bbox(self.extent, self.srs, outname=outname, format=format, overwrite=overwrite)
     
+    def clone(self):
+        return feature2vector(self.getfeatures(), ref=self)
+    
     def close(self):
         """
         closes the OGR vector file connection

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -808,6 +808,9 @@ def intersect(obj1, obj2):
     if not isinstance(obj1, Vector) or not isinstance(obj2, Vector):
         raise RuntimeError('both objects must be of type Vector')
     
+    obj1 = obj1.clone()
+    obj2 = obj2.clone()
+    
     obj1.reproject(obj2.srs)
     
     #######################################################


### PR DESCRIPTION
This improves the function raster.stack by fixing errors related to passing a shapefile or Vector geometry to the function, which occasionally lead to images missing in the intersect selection. Furthermore the need to write a temporary directory was removed by creating all VRT files in memory.

This change required a new method Vector.clone and its application in function vector.intersect. This function now first clones all input Vector objects, which it should have done all along.

Function ancillary.multicore now works differently on Windows than on Linux since several errors were detected during testing.

Furthermore compatibility with Python3 is further improved by fixing regular expression DeprecationWarnings