### PR TITLE
compatibility with GDAL3

### DIFF
--- a/spatialist/__init__.py
+++ b/spatialist/__init__.py
@@ -3,7 +3,8 @@ from . import envi
 from . import ancillary
 from . import raster
 from . import sqlite_util
-from .auxil import crsConvert, haversine, gdalbuildvrt, gdalwarp, gdal_translate, ogr2ogr, gdal_rasterize
+from .auxil import crsConvert, haversine, gdalbuildvrt, gdalwarp, gdal_translate, ogr2ogr, gdal_rasterize, \
+    utm_autodetect
 
 from .vector import Vector, bbox, centerdist, intersect
 from .raster import Raster, stack, rasterize

--- a/spatialist/auxil.py
+++ b/spatialist/auxil.py
@@ -62,6 +62,8 @@ def crsConvert(crsIn, crsOut):
         if isinstance(crsIn, str):
             try:
                 srs.SetFromUserInput(crsIn)
+                if gdal.__version__ >= '3.0':
+                    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
             except RuntimeError:
                 raise TypeError('crsIn not recognized; must be of type WKT, PROJ4 or EPSG\n'
                                 '  was: "{}" of type {}'.format(crsIn, type(crsIn).__name__))
@@ -304,6 +306,8 @@ def utm_autodetect(spatial, crsOut):
     north = lat > 0
     utm_cs = osr.SpatialReference()
     utm_cs.SetWellKnownGeogCS('WGS84')
+    if gdal.__version__ >= '3.0':
+        utm_cs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
     utm_cs.SetUTM(zone, north)
     return crsConvert(utm_cs, crsOut)
 

--- a/spatialist/tests/test_spatial.py
+++ b/spatialist/tests/test_spatial.py
@@ -5,7 +5,7 @@ import platform
 import numpy as np
 from osgeo import ogr
 from spatialist import crsConvert, haversine, Raster, stack, ogr2ogr, gdal_translate, gdal_rasterize, bbox, rasterize, \
-    gdalwarp
+    gdalwarp, utm_autodetect
 from spatialist.raster import Dtype
 from spatialist.vector import feature2vector, dissolve, Vector, intersect
 from spatialist.envi import hdr, HDRobject
@@ -44,6 +44,9 @@ def test_Vector(testdata):
         bbox1.getFeatureByIndex(1)
     bbox1.reproject(4326)
     assert bbox1.proj4.strip() == '+proj=longlat +datum=WGS84 +no_defs'
+    ext = {key: round(val, 3) for key, val in bbox1.extent.items()}
+    assert ext == {'xmax': 4.554, 'xmin': 4.487, 'ymax': 43.614, 'ymin': 43.574}
+    assert utm_autodetect(bbox1, 'epsg') == 32631
     assert isinstance(bbox1['fid=0'], Vector)
     with pytest.raises(RuntimeError):
         test = bbox1[0.1]


### PR DESCRIPTION
This addresses the changes made in GDAL3 described in the 2.4 to 3.0 migration guide [here](https://github.com/OSGeo/gdal/blob/master/gdal/MIGRATION_GUIDE.TXT). Additional tests were included to ensure functionality for both GDAL 2.x and 3.x.