### PR TITLE
Remove unused parameter from `Raster.write`

### DIFF
--- a/spatialist/raster.py
+++ b/spatialist/raster.py
@@ -1079,8 +1079,6 @@ class Raster(object):
             the file format; e.g. 'GTiff'
         nodata: int or float
             the nodata value to write to the file
-        compress_tif: bool
-            if the format is GeoTiff, compress the written file?
         overwrite: bool
             overwrite an already existing file? Only applies if `update` is `False`.
         cmap: :osgeo:class:`gdal.ColorTable`


### PR DESCRIPTION
Not used or referenced anywhere in the code. Guess you forgot to delete it? 