### PR TITLE
improved EPSG code search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: python
 sudo: required
 cache:
@@ -26,7 +26,8 @@ python:
   - '3.7'
 
 install:
-  - pip install --ignore-installed six # install six inside the venv since the system version is too old
+  - mkdir -p ~/.cache/pip/wheels # remove warning "Url 'file:///home/travis/.cache/pip/wheels' is ignored: it is neither a file nor a directory."
+  - pip install --ignore-installed setuptools pip six certifi # install packages inside the venv if the system version is too old
   - pip install numpy
   - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"
   - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import os
 
 directory = os.path.abspath(os.path.dirname(__file__))
@@ -10,7 +10,7 @@ with open(os.path.join(directory, 'requirements.txt'), 'r') as req:
     requirements = req.read().split('\n')
 
 setup(name='spatialist',
-      packages=find_packages(),
+      packages=find_namespace_packages(),
       include_package_data=True,
       setup_requires=['setuptools_scm'],
       use_scm_version=True,

--- a/spatialist/auxil.py
+++ b/spatialist/auxil.py
@@ -350,7 +350,7 @@ def __osr2epsg(srs):
     Parameters
     ----------
     srs: :osgeo:class:`osr.SpatialReference`
-        a SRS to be converted
+        an SRS to be converted
 
     Returns
     -------
@@ -363,7 +363,16 @@ def __osr2epsg(srs):
     """
     srs = srs.Clone()
     try:
-        srs.AutoIdentifyEPSG()
+        try:
+            srs.AutoIdentifyEPSG()
+        except RuntimeError:
+            # Sometimes EPSG identification might fail
+            # but a match exists for which it does not.
+            matches = srs.FindMatches()
+            for srs, confidence in matches:
+                if confidence == 100:
+                    srs.AutoIdentifyEPSG()
+                    break
         code = int(srs.GetAuthorityCode(None))
         # make sure the EPSG code actually exists
         srsTest = osr.SpatialReference()


### PR DESCRIPTION
This makes it possible to get the EPSG code for the following CRS using [crsConvert](https://spatialist.readthedocs.io/en/latest/spatialist.html#spatialist.auxil.crsConvert) by finding a matching CRS that does contain it.
without code:
```
PROJCS["WGS 84 / UTM zone 32N",
    GEOGCS["WGS 84",
        DATUM["WGS_1984",
            SPHEROID["WGS 84",6378137,298.257223563,
                AUTHORITY["EPSG","7030"]],
            AUTHORITY["EPSG","6326"]],
        PRIMEM["Greenwich",0,
            AUTHORITY["EPSG","8901"]],
        UNIT["degree",0.0174532925199433]],
    PROJECTION["Transverse_Mercator"],
    PARAMETER["central_meridian",9],
    PARAMETER["latitude_of_origin",0],
    PARAMETER["scale_factor",0.9996],
    PARAMETER["false_easting",500000],
    PARAMETER["false_northing",0],
    UNIT["Meter",1],
    AXIS["Easting",EAST],
    AXIS["Northing",NORTH]]
```
match with EPSG code:
```
PROJCS["WGS 84 / UTM zone 32N",
    GEOGCS["WGS 84",
        DATUM["WGS_1984",
            SPHEROID["WGS 84",6378137,298.257223563,
                AUTHORITY["EPSG","7030"]],
            AUTHORITY["EPSG","6326"]],
        PRIMEM["Greenwich",0,
            AUTHORITY["EPSG","8901"]],
        UNIT["degree",0.0174532925199433,
            AUTHORITY["EPSG","9122"]],
        AUTHORITY["EPSG","4326"]],
    PROJECTION["Transverse_Mercator"],
    PARAMETER["central_meridian",9],
    PARAMETER["latitude_of_origin",0],
    PARAMETER["scale_factor",0.9996],
    PARAMETER["false_easting",500000],
    PARAMETER["false_northing",0],
    UNIT["Meter",1],
    AXIS["Easting",EAST],
    AXIS["Northing",NORTH],
    AUTHORITY["EPSG","32632"]]
```