### PR TITLE
improved options for setting vector fields

### DIFF
--- a/docs/source/spatialist.rst
+++ b/docs/source/spatialist.rst
@@ -34,7 +34,7 @@ Vector Tools
 ------------
 
 .. automodule:: spatialist.vector
-    :members: bbox, boundary, feature2vector, intersect, vectorize, wkt2vector
+    :members: bbox, boundary, centerdist, dissolve, feature2vector, intersect, set_field, vectorize, wkt2vector
     :undoc-members:
     :show-inheritance:
 
@@ -43,8 +43,11 @@ Vector Tools
 
         bbox
         boundary
+        centerdist
+        dissolve
         feature2vector
         intersect
+        set_field
         vectorize
         wkt2vector
 

--- a/spatialist/tests/test_spatial.py
+++ b/spatialist/tests/test_spatial.py
@@ -99,8 +99,7 @@ def test_dissolve(tmpdir, travis, testdata):
 
 def test_Raster(tmpdir, testdata):
     with pytest.raises(RuntimeError):
-        with Raster(1) as ras:
-            print(ras)
+        ras =  Raster(1)
     with Raster(testdata['tif']) as ras:
         print(ras)
         assert ras.bands == 1
@@ -186,8 +185,7 @@ def test_Raster_extract(testdata):
 
 def test_Raster_filestack(testdata):
     with pytest.raises(RuntimeError):
-        with Raster([testdata['tif']]) as ras:
-            print(ras)
+        ras = Raster([testdata['tif']])
     with Raster([testdata['tif'], testdata['tif2']]) as ras:
         assert ras.bands == 2
         arr = ras.array()
@@ -448,8 +446,10 @@ def test_addfield():
         now = now.astimezone(timezone.utc)  # UTC timezone
         box.addfield(name='test12', type=ogr.OFTDateTime, values=[now])
         with pytest.raises(ValueError):
-            # Date and Time are not supported
+            # Date type is not supported
             box.addfield(name='test13', type=ogr.OFTDate, values=[now])
+        with pytest.raises(ValueError):
+            # Time type is not supported
             box.addfield(name='test14', type=ogr.OFTTime, values=[now])
         with pytest.raises(TypeError):
             # value must be a datetime object

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -156,9 +156,9 @@ class Vector(object):
             for field_name, value in fields.items():
                 if field_name not in self.fieldnames:
                     raise IOError('field "{}" is missing'.format(field_name))
-                field_index = self.fieldnames.index(field_name)
-                field_type = feature.GetFieldDefnRef(field_index).GetType()
-                field_type_name = feature.GetFieldDefnRef(field_index).GetTypeName()
+                field_defn = feature.GetFieldDefnRef(field_name)
+                field_type = field_defn.GetType()
+                field_type_name = field_defn.GetTypeName()
                 try:
                     set_field(target=feature, name=field_name,
                               type=field_type, values=value)

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -830,6 +830,18 @@ def boundary(vectorobject, expression=None, outname=None):
 
 
 def centerdist(obj1, obj2):
+    """
+    Get the center distance between two vector objects.
+    
+    Parameters
+    ----------
+    obj1: Vector
+    obj2: Vector
+
+    Returns
+    -------
+    float
+    """
     if not isinstance(obj1, Vector) or isinstance(obj2, Vector):
         raise IOError('both objects must be of type Vector')
     
@@ -847,6 +859,7 @@ def centerdist(obj1, obj2):
 def dissolve(infile, outfile, field, layername=None):
     """
     dissolve the polygons of a vector file by an attribute field
+    
     Parameters
     ----------
     infile: str

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -153,17 +153,20 @@ class Vector(object):
         feature.SetGeometry(geometry)
         
         if fields is not None:
-            for fieldname, value in fields.items():
-                if fieldname not in self.fieldnames:
-                    raise IOError('field "{}" is missing'.format(fieldname))
+            for field_name, value in fields.items():
+                if field_name not in self.fieldnames:
+                    raise IOError('field "{}" is missing'.format(field_name))
+                field_index = self.fieldnames.index(field_name)
+                field_type = feature.GetFieldDefnRef(field_index).GetType()
+                field_type_name = feature.GetFieldDefnRef(field_index).GetTypeName()
                 try:
-                    feature.SetField(fieldname, value)
-                except NotImplementedError as e:
-                    fieldindex = self.fieldnames.index(fieldname)
-                    fieldtype = feature.GetFieldDefnRef(fieldindex).GetTypeName()
-                    message = str(e) + '\ntrying to set field {} (type {}) to value {} (type {})'
-                    message = message.format(fieldname, fieldtype, value, type(value))
-                    raise (NotImplementedError(message))
+                    set_field(target=feature, name=field_name,
+                              type=field_type, values=value)
+                except Exception as e:
+                    message = str(e) + (f'\ntrying to set field {field_name} '
+                                        f'(type {field_type_name}) to value '
+                                        f'{value} (type {type(value)})')
+                    raise RuntimeError(message) from e
         
         self.layer.CreateFeature(feature)
         feature = None

--- a/spatialist/vector.py
+++ b/spatialist/vector.py
@@ -1061,7 +1061,7 @@ def set_field(target, name, type, width=10, values=None):
     
     if type_name in ['String', 'Integer', 'Real', 'Binary', 'DateTime']:
         method_name = 'SetField'
-    elif type_name in ['StringList', 'DoubleList', 'IntegerList',
+    elif type_name in ['StringList', 'IntegerList',
                        'Integer64', 'Integer64List']:
         method_name = f'SetField{type_name}'
     elif type_name == 'RealList':


### PR DESCRIPTION
- new function `vector.set_field` for setting fields of `Vector` and `ogr.Feature` objects
  - now used by `Vector.addfield` (which it was outsourced from) and `Vector.addfeature` (whose field setting functionality was very limited before)
  - new option to pass `datetime.datetime` objects and setting them as `DateTime` type field