### PR TITLE
Vector.to_geopandas datetime fix

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org', None),
     'numpy': ('https://numpy.org/doc/stable', None),
     'osgeo': ('https://gdal.org', None),
+    'pandas': ('https://pandas.pydata.org/docs', None),
     'pathos': ('https://pathos.readthedocs.io/en/latest', None),
     'python': ('https://docs.python.org/3', None)
 }

--- a/docs/source/spatialist.rst
+++ b/docs/source/spatialist.rst
@@ -85,7 +85,7 @@ Ancillary Functions
 -------------------
 
 .. automodule:: spatialist.ancillary
-    :members: dissolve, finder, HiddenPrints, multicore, parse_literal, run, sampler, which, parallel_apply_along_axis
+    :members: dissolve, finder, HiddenPrints, multicore, ogr_datetime_to_pandas, parse_literal, run, sampler, which, parallel_apply_along_axis
     :undoc-members:
     :show-inheritance:
 

--- a/spatialist/ancillary.py
+++ b/spatialist/ancillary.py
@@ -1,6 +1,6 @@
 ##############################################################
 # core routines for software spatialist
-# John Truckenbrodt 2014-2020,2024
+# John Truckenbrodt 2014-2025
 ##############################################################
 """
 This script gathers central functions and classes for general applications
@@ -25,6 +25,7 @@ import tarfile as tf
 import zipfile as zf
 from typing import Iterable, List
 import numpy as np
+import pandas as pd
 import progressbar as pb
 
 try:
@@ -794,3 +795,53 @@ def sampler(mask, samples=None, dim=1, replace=False, seed=42):
         return out
     else:
         raise ValueError("'dim' must either be 1 or 2")
+
+
+def ogr_datetime_to_pandas(ogr_dt):
+    """
+    Convert an OGR DateTime tuple to a pandas Timestamp.
+
+    Parameters
+    ----------
+    ogr_dt : tuple
+        A 7-element tuple in the format (year, month, day, hour, minute,
+        second, tz_flag) as returned by :meth:`osgeo.ogr.Feature.GetFieldAsDateTime`.
+
+    Returns
+    -------
+    pandas.Timestamp
+        A pandas Timestamp object representing the input datetime.
+
+    Notes
+    -----
+    The `tz_flag` is interpreted as follows:
+    
+    - 0: Unknown timezone (returns naive timestamp).
+    - 1: Local time (returns naive timestamp).
+    - 100: UTC.
+    - >100: Offset from UTC in minutes (applied to UTC).
+
+    Examples
+    --------
+    >>> ogr_datetime_to_pandas((2024, 9, 1, 11, 16, 2, 100))
+    Timestamp('2024-09-01 11:16:02+0000', tz='UTC')
+    
+    Raises
+    ------
+    RuntimeError
+    """
+    
+    year, month, day, hour, minute, second, tz_flag = ogr_dt
+    
+    try:
+        dt = pd.Timestamp(year, month, day, hour, minute, int(second))
+        if tz_flag == 100:
+            return dt.tz_localize('UTC')
+        elif tz_flag > 100:
+            offset_min = tz_flag - 100
+            offset = pd.Timedelta(minutes=offset_min)
+            return dt.tz_localize('UTC') + offset
+        else:
+            return dt
+    except Exception:
+        raise RuntimeError('Failed to convert datetime to pandas Timestamp')


### PR DESCRIPTION
`Feature.items()` converts OGR datetime objects to strings. However, these strings can have different formats, e.g. 
2024/09/01 11:16:02+00   
2024/09/01 11:16:04.542+00   

To make sure that timestamps are correctly handled, the string conversion is no longer relied on. A custom function directly converts the datetime tuple to a pandas.Timestamp object.